### PR TITLE
Improve version command output readability

### DIFF
--- a/pkg/cmd/versionCommand.go
+++ b/pkg/cmd/versionCommand.go
@@ -31,6 +31,7 @@ func newVersionCmd() *versionCmd {
 				fmt.Println()
 				fmt.Printf("version %v\n", release.Version)
 				release.IsNeedingUpdate()
+				fmt.Println()
 			},
 		},
 	}


### PR DESCRIPTION
Add an extra newline in the version command output to enhance readability.