### PR TITLE
Specify binary name for Kinde CLI in Homebrew Cask configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -144,6 +144,7 @@ homebrew_casks:
       email: support@kinde.com
     homepage: https://kinde.com
     description: Kinde CLI utility
+    binary: kinde
     completions:
       bash: "kinde-completion.bash"
       zsh: "kinde-completion.zsh"


### PR DESCRIPTION
Define the binary name for the Kinde CLI in the Homebrew Cask configuration to ensure proper installation and usage.