### PR TITLE
Specify binary name and add fields for Kinde CLI in Homebrew Cask configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -144,6 +144,7 @@ homebrew_casks:
       email: support@kinde.com
     homepage: https://kinde.com
     description: Kinde CLI utility
+    binary: kinde
     completions:
       bash: "kinde-completion.bash"
       zsh: "kinde-completion.zsh"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,7 +135,8 @@ changelog:
       - "^test:"
 
 homebrew_casks:
-  - repository:
+  - name: kinde-cli
+    repository:
       owner: kinde-oss
       name: homebrew-kinde-cli
       token: "{{ .Env.GORELEASER_GITHUB_TOKEN }}" # This token can access the repo, but GITHUB_TOKEN cannot
@@ -145,6 +146,8 @@ homebrew_casks:
     homepage: https://kinde.com
     description: Kinde CLI utility
     binary: kinde
+    ids:
+      - cli
     completions:
       bash: "kinde-completion.bash"
       zsh: "kinde-completion.zsh"


### PR DESCRIPTION
Define the binary name and include name and IDs fields for the Kinde CLI in the Homebrew Cask configuration.