### PR TITLE
Refactor Homebrew Cask configuration for Kinde CLI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,11 +146,7 @@ homebrew_casks:
     homepage: https://kinde.com
     description: Kinde CLI utility
     binary: kinde
-    ids:
-      - cli
-    completions:
-      bash: "kinde-completion.bash"
-      zsh: "kinde-completion.zsh"
+
     hooks:
       post:
         install: |


### PR DESCRIPTION
Remove unnecessary fields from the Homebrew Cask configuration for the Kinde CLI, streamlining the setup.