### PR TITLE
Enable CGO support and update Kinde Go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 toolchain go1.24.5
 
-require github.com/kinde-oss/kinde-go v0.1.1
+require github.com/kinde-oss/kinde-go v0.1.4
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/jwalton/go-supportscolor v1.2.0 h1:g6Ha4u7Vm3LIsQ5wmeBpS4gazu0UP1DRDE
 github.com/jwalton/go-supportscolor v1.2.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/kinde-oss/kinde-go v0.1.1 h1:2kzvjNXbDYPoVXeF8c3Kz6ZXhDmcNdYDWZPJYO9IFlo=
 github.com/kinde-oss/kinde-go v0.1.1/go.mod h1:e2rGwxkFETGDsQvEbcOXEvJ7qVd2Sy78MYcq62wVkoM=
+github.com/kinde-oss/kinde-go v0.1.4 h1:8p8T/7HdIZZtWGKcb2PYcq7wcvZaGP+4qduMBkO25Z4=
+github.com/kinde-oss/kinde-go v0.1.4/go.mod h1:cJ929GugPuvSu1zBgOuuj6xJQp+vEAMsbdcTeetZ+Go=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
Enable CGO support for builds and update the Kinde Go dependency to version 0.1.4. This change enhances compatibility and functionality.